### PR TITLE
fixing href docs issues for custom fields

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -22,7 +22,7 @@ For a deeper understanding of the framework, check out the [Pret tutorials](http
     ---
     Run the Quaero Explorer demo app and discover its features: persisting annotations, collaborating, and more.
 
-=== card {: href=/tutorials/customize-explorer/ }
+=== card {: href=/tutorials/custom-fields/ }
 
     :fontawesome-solid-robot:
     **Customize the Data Explorer**


### PR DESCRIPTION
In the documentation, the "Adding custom fields tutorial" is currently pointing to the wrong link "https://percevalw.github.io/metanno/latest/tutorials/customize-explorer" instead of "https://percevalw.github.io/metanno/latest/tutorials/custom-fields/"