### PR TITLE
fix: trigger on_hover_spans also when cursor leaves span while leaving line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix `on_hover_spans` callback to trigger also when the cursor leaves a span while leaving its line
+
 ## v1.0.0 (2025-05-10)
 
 - Added multi-document rendering to `DataWidgetFactory.create_text_widget` with `docs_mode="lead" | "selected" | "all"` and an optional `container_renderer` for custom document wrappers (e.g. sticky headers)

--- a/client/components/AnnotatedText/index.tsx
+++ b/client/components/AnnotatedText/index.tsx
@@ -317,7 +317,11 @@ const Line = React.memo(
           }
         })
         .filter((e) => !!e);
-      let newSet = new Set(hitElements.map((e) => e.getAttribute("span_key")));
+      let newSet = new Set(
+        hitElements
+          .map((e) => e.getAttribute("span_key"))
+          .filter((x) => x !== null)
+      );
       let changed = false;
       // @ts-ignore
       hoveredKeys.current.forEach(
@@ -346,6 +350,9 @@ const Line = React.memo(
       if (!hoveredKeys) return;
       // @ts-ignore
       hoveredKeys.current.forEach((x) => handleMouseLeaveSpan(event, x));
+      if (hoveredKeys.current.size > 0 && handleMouseHoverSpans) {
+        handleMouseHoverSpans(event, []);
+      }
       hoveredKeys.current.clear();
     };
     const onMouseUp = (e) => {


### PR DESCRIPTION
- Fix `on_hover_spans` callback to trigger also when the cursor leaves a span while leaving its line